### PR TITLE
Lighten validation on the Athelete ID field to enable numerical values (especially for copy and paste)

### DIFF
--- a/web/pages/BarcodeForm.tsx
+++ b/web/pages/BarcodeForm.tsx
@@ -47,7 +47,13 @@ const formReducer = (values: typeof formInitialValues, update: [string, string])
       return { ...formInitialValues }
     }
     case 'athleteId': {
-      const transformedVal = newValue.toUpperCase()
+      let transformedVal = newValue.toUpperCase()
+
+      // Any numerical values should just prepend the 'A'
+      if (transformedVal.length > 0 && transformedVal.charAt(0) !== 'A') {
+        transformedVal = `A${transformedVal}`;
+      }
+
       return /^$|^A[1-9]?$|^A[1-9][0-9]{0,8}$/.test(transformedVal)
         ? { ...values, athleteId: transformedVal }
         : values


### PR DESCRIPTION
I had an issue when using this form where I tried to paste in my athelete ID number and was just going to manually add the 'A' at the beginning. In order to fix this, I've side-stepped the validation and just manually prepended the 'A'.

An alternative approach is to move the validation to the `handleOpenProfile` and show a custom warning for this field.